### PR TITLE
Scope the debug-logs skill to this repo

### DIFF
--- a/.claude/install.sh
+++ b/.claude/install.sh
@@ -97,8 +97,11 @@ _impl_in_nonmain_worktree() {
 # NEVER the invoking (possibly linked) worktree, so the link survives a
 # worktree prune.
 LOCAL_SKILLS_SRC="$MAIN_WORKTREE/modules/app/agent-repl/skills"
+# NOTE: debug-logs is NOT here — it is a PROJECT-scoped skill, registered
+# via the checked-in <repo>/.claude/skills/debug-logs symlink rather than
+# a ~/.claude/skills user-level link (it is doom-specific and should only
+# be discoverable when working in this repo).
 LOCAL_SKILLS=(
-  "debug-logs"
   "profile"
   "runtime-eval-code"
   "workspace-close"

--- a/.claude/skills/debug-logs
+++ b/.claude/skills/debug-logs
@@ -1,0 +1,1 @@
+../../modules/app/agent-repl/skills/debug-logs

--- a/.claude/test-install.sh
+++ b/.claude/test-install.sh
@@ -22,7 +22,9 @@ pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); shift; if [ $# -gt 0 ]; then printf '%s\n' "$@" | sed 's/^/        /'; fi; }
 
 # Local skills install.sh expects to find under modules/app/agent-repl/skills/.
-LOCAL_SKILL_NAMES=( debug-logs profile runtime-eval-code workspace-close workspace-open emit-workspace-commands.sh )
+# debug-logs is deliberately absent: it is PROJECT-scoped (checked-in
+# <repo>/.claude/skills symlink), not a user-level installed skill.
+LOCAL_SKILL_NAMES=( profile runtime-eval-code workspace-close workspace-open emit-workspace-commands.sh )
 
 # Build a synthetic repo containing a fresh copy of install.sh, the
 # pre-commit hook, a manifest with one cached skill 'foo' whose impl is
@@ -156,12 +158,12 @@ test_local_skills_link_to_main_worktree() {
     bash "$repo/linked-wt/.claude/install.sh" install >"$repo/.install.log" 2>&1
   LAST_RC=$?
   set -e
-  local actual; actual="$(readlink "$home/.claude/skills/debug-logs" 2>/dev/null || echo MISSING)"
+  local actual; actual="$(readlink "$home/.claude/skills/profile" 2>/dev/null || echo MISSING)"
   # install.sh links to the PHYSICAL main-worktree path (matching git's
   # canonical `worktree list` output), so canonicalize the tmpdir-based
   # expectation too (mktemp yields /var/... which symlinks to /private/var/...
   # on macOS).
-  local expected; expected="$(cd "$repo" && pwd -P)/modules/app/agent-repl/skills/debug-logs"
+  local expected; expected="$(cd "$repo" && pwd -P)/modules/app/agent-repl/skills/profile"
   if [ "$LAST_RC" -eq 0 ] && [ "$actual" = "$expected" ]; then
     pass "local skills link to main worktree when run from a linked worktree"
   else

--- a/modules/app/agent-repl/install.el
+++ b/modules/app/agent-repl/install.el
@@ -121,15 +121,18 @@ Must match the `SKILLS_SRC' default in `.claude/install.sh' (or the
   :group 'agent-repl)
 
 (defconst agent-repl--managed-local-skills
-  '("debug-logs"
-    "runtime-eval-code"
+  '("runtime-eval-code"
     "workspace-close"
     "workspace-open"
     "emit-workspace-commands.sh")
   "Bare names for repo-local managed skills.
 Sourced from `agent-repl-local-skills-src-dir' (this repo's
 `modules/app/agent-repl/skills/').  Must match the `LOCAL_SKILLS'
-array in `.claude/install.sh'.")
+array in `.claude/install.sh'.
+
+debug-logs is deliberately absent: it is PROJECT-scoped via the
+checked-in `<repo>/.claude/skills/debug-logs' symlink, not a
+user-level `~/.claude/skills' link.")
 
 (defcustom agent-repl-local-skills-src-dir
   (when load-file-name

--- a/modules/app/agent-repl/test-install.el
+++ b/modules/app/agent-repl/test-install.el
@@ -787,8 +787,11 @@ the defcustoms.  Returns the list of dests created."
 ;;;; ---- local-skill specific tests ----
 
 (ert-deftest agent-repl-test-managed-local-skills-nonempty ()
-  "Repo-local skills list must include `debug-logs' (regression guard)."
-  (should (member "debug-logs" agent-repl--managed-local-skills)))
+  "Repo-local skills list must include `runtime-eval-code' (regression guard).
+debug-logs is deliberately NOT in the list — it is project-scoped via
+the checked-in `<repo>/.claude/skills/debug-logs' symlink."
+  (should (member "runtime-eval-code" agent-repl--managed-local-skills))
+  (should-not (member "debug-logs" agent-repl--managed-local-skills)))
 
 (ert-deftest agent-repl-test-local-skills-src-dir-default ()
   "Default `agent-repl-local-skills-src-dir' points at this module's


### PR DESCRIPTION
## Jira Ticket Link

## Motivation
<pre>
1. 🎯 Desired functionality: debug-logs is discoverable only inside this repo.
├── 1.1. A checked-in <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/skills/debug-logs">.claude/skills/debug-logs</a> relative symlink points at the module source.
└── 1.2. Invoking <mark><b>/debug-logs</b></mark> from a clone of this repo resolves the skill, while invoking it from any other project does not surface it.

2. 🔁 Best current alternative: the prior user-level install.
├── 2.1. Before this change <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/install.sh#L104">install.sh</a> linked debug-logs into <mark><b>~/.claude/skills/debug-logs</b></mark> for every repo on the machine.
└── 2.2. That global link surfaced a doom-specific skill inside unrelated projects, the gap this PR closes.
</pre>

## Existing limitation
<pre>
1. 📋 debug-logs was registered across four managed lists that user-level-link it.
├── 1.1. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/install.sh#L104">LOCAL_SKILLS</a> in install.sh drove the <mark><b>~/.claude/skills</b></mark> symlink.
├── 1.2. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/modules/app/agent-repl/install.el#L123">agent-repl--managed-local-skills</a> mirrored that list for the elisp installer.
└── 1.3. Both <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/test-install.sh#L27">test-install.sh</a> and <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/modules/app/agent-repl/test-install.el#L789">test-install.el</a> asserted debug-logs was present.
</pre>

## Implementation
<pre>
1. 🛡️ Backwards compatibility.
├── 1.1. The skill's behavior and source stay identical, only its install scope moves from user-level to project-level.
└── 1.2. A machine that previously had <mark><b>~/.claude/skills/debug-logs</b></mark> has that user-level link removed on the next install run, replaced by the in-repo symlink.

2. 🎚️ Scope promotion to a checked-in project skill.
├── 2.1. debug-logs is dropped from every managed user-level list.
└── 2.2. A committed <mark><b>.claude/skills/debug-logs</b></mark> symlink is the sole registration path now.

3. 🔗 Linkage probe retargeted.
└── 3.1. The main-worktree linkage test now probes <mark><b>profile</b></mark> because debug-logs no longer installs user-level.
</pre>

## Code added
<pre>
1. 🔗 <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/skills/debug-logs">.claude/skills/debug-logs</a> symlink added.
├── 1.1. Motivation: register debug-logs as a project-scoped skill discoverable only within this repo.
└── 1.2. Function: a relative symlink resolving to <mark><b>modules/app/agent-repl/skills/debug-logs</b></mark> so SKILL.md edits go live without a copy step.
</pre>

## Code changed
<pre>
1. ✂️ Source installers drop debug-logs.
├── 1.1. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/install.sh#L104">LOCAL_SKILLS</a> no longer links it into <mark><b>~/.claude/skills</b></mark>.
└── 1.2. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/modules/app/agent-repl/install.el#L123">agent-repl--managed-local-skills</a> drops the matching elisp entry.

2. 🧪 Installer tests retargeted off debug-logs.
├── 2.1. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/.claude/test-install.sh#L27">LOCAL_SKILL_NAMES</a> and the main-worktree linkage probe now use <mark><b>profile</b></mark>.
└── 2.2. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/modules/app/agent-repl/test-install.el#L789">agent-repl-test-managed-local-skills-nonempty</a> now asserts debug-logs is absent from the managed list.
</pre>

## Testing
<pre>
1. ✅ Installer suites both pass green.
├── 1.1. <mark><b>bash .claude/test-install.sh</b></mark> passes 12/12, including the retargeted main-worktree linkage probe.
└── 1.2. The ERT <mark><b>test-install.el</b></mark> suite passes 91/91.

2. 🚧 Regression guard flipped.
└── 2.1. <a href="https://github.com/dwcoates/doom-emacs-config/blob/DWC/debug-logs-scope-gsx/modules/app/agent-repl/test-install.el#L789">agent-repl-test-managed-local-skills-nonempty</a> now asserts debug-logs is not managed user-level while runtime-eval-code still is.
</pre>

#### For More Human Review

- `.claude/install.sh:104` `LOCAL_SKILLS` array, de-registered debug-logs so the user-level `~/.claude/skills` link is no longer created.
- `.claude/skills/debug-logs` new checked-in relative symlink, the sole registration path for the now project-scoped skill.